### PR TITLE
Do not write out row numbers in extract() csv files; update documentDatastoreTables

### DIFF
--- a/sources/framework/visioneval/R/query.R
+++ b/sources/framework/visioneval/R/query.R
@@ -225,11 +225,17 @@ listDatasets <- function(Table, Group, QueryPrep_ls) {
 #' @param QueryPrep_ls a list created by calling the prepareForDatastoreQuery
 #' function which identifies the datastore location(s), listing(s), and
 #' functions for listing and read the datastore(s).
+#' @param zip_files an argument to specify whether the inventory should be saved as 
+#' a single .zip file
 #' @return a logical identifying whether the archive file has been saved.
 #' @export
 #' @import filesstrings
-documentDatastoreTables <- function(SaveArchiveName, QueryPrep_ls) {
-  GroupNames_ <- QueryPrep_ls$Listing$Datastore$Datastore$groupname
+documentDatastoreTables <- function(SaveArchiveName, QueryPrep_ls, zip_files = TRUE) {
+  
+  # Use the Dir from QueryPrep_ls as the Datastore name
+  Datastore_dir = QueryPrep_ls$Dir
+  
+  GroupNames_ <- QueryPrep_ls$Listing[[Datastore_dir]]$Datastore$groupname
   Groups_ <- GroupNames_[-grep("/", GroupNames_)]
   if (any(Groups_ == "")) {
     Groups_ <- Groups_[-(Groups_ == "")]
@@ -239,16 +245,17 @@ documentDatastoreTables <- function(SaveArchiveName, QueryPrep_ls) {
   for (Group in Groups_) {
     GroupDir <- file.path(TempDir, Group)
     dir.create(GroupDir)
-    Tables_ <- listTables(Group, QueryPrep_ls)$Datastore
+    Tables_ <- listTables(Group, QueryPrep_ls)[[Datastore_dir]]
     for (tb in Tables_) {
-      Listing_df <- listDatasets(tb, Group, QueryPrep_ls)$Datastore
+      Listing_df <- listDatasets(tb, Group, QueryPrep_ls)[[Datastore_dir]]
       write.table(Listing_df, file = file.path(GroupDir, paste0(tb, ".csv")),
                   row.names = FALSE, col.names = TRUE, sep = ",")
     }
   }
-  zip(paste0(SaveArchiveName, ".zip"), TempDir)
-  remove_dir(TempDir)
-  TRUE
+  if(zip_files){
+    zip(paste0(SaveArchiveName, ".zip"), TempDir)
+    suppressMessages( remove_dir(TempDir) )
+  }  
 }
 # #Example
 # QPrep_ls <- prepareForDatastoreQuery(

--- a/sources/tools/models.R
+++ b/sources/tools/models.R
@@ -656,9 +656,9 @@ ve.model.extract <- function(
         data <- results[[f]]
         out.path <- file.path(self$modelPath[s],saveTo)
         if ( ! dir.exists(out.path) ) dir.create(out.path,recursive=TRUE)
-        fn <- file.path(out.path,f)
-        write.csv(data,file=fn)
-        if (!quiet) message("Write output file: ",gsub(ve.runtime,"",fn))
+        fn <- file.path(out.path, f)
+        write.csv(data, file = fn, row.names = F)
+        if (!quiet) message("Write output file: ", gsub(ve.runtime, "", fn))
       }
     )
   } else {


### PR DESCRIPTION
Tested with VERPAT, using ve.build() and the following code:

```
# Default VERPAT ---- 
rpat <- openModel('VERPAT')

# Run the default model
rpat$run() 

# Select Azone, Bzone, Household, and Marea geographies.
rpat$tablesSelected <- c('Azone', 'Bzone', 'Household', 'Marea')

# Extract outputs to csv files
rpat$extract()
```

`extract()` is nicer without row numbers of the data frame written out.  